### PR TITLE
Integrate Grok AI resume analysis with Rust backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,24 @@ grok-service/
 - Health check at `/health`
 - Use Pydantic models for request/response schemas
 
+## Logging Standards
+
+**Never use print statements for logging. Always use the logging library of each project.**
+
+### Rust (server/)
+- Use the `log` crate with `info!`, `error!`, `debug!`, `warn!` macros
+- Logger is initialized with `env_logger` in main.rs
+- Example: `log::info!("Processing request for {}", id);`
+
+### Python (grok-service/)
+- Use the `logging` module from Python standard library
+- Get logger with: `logger = logging.getLogger(__name__)`
+- Example: `logger.info("Processing request for %s", id)`
+
+### TypeScript/Svelte (ui/)
+- Use `console.log`, `console.error`, `console.warn` for development
+- Consider structured logging for production
+
 ## File Naming Conventions
 
 - Components: `kebab-case.svelte` (e.g., `talent-card.svelte`)

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ grok-install: $(GROK_VENV)
 	$(GROK_PYTHON) -m pip install -e "grok-service[dev]"
 
 grok-dev: $(GROK_VENV)
-	cd grok-service && ../.venv/bin/python -m uvicorn grok_service.main:app --reload --host 0.0.0.0 --port 8001
+	cd grok-service && GRPC_DNS_RESOLVER=native .venv/bin/python -m uvicorn grok_service.main:app --reload --host 0.0.0.0 --port 8001
 
 grok-format: $(GROK_VENV)
 	$(GROK_PYTHON) -m black grok-service/src grok-service/tests
@@ -84,7 +84,7 @@ grok-lint: $(GROK_VENV)
 	$(GROK_PYTHON) -m ruff check grok-service/src grok-service/tests
 
 grok-test: $(GROK_VENV)
-	cd grok-service && ../.venv/bin/python -m pytest
+	cd grok-service && GRPC_DNS_RESOLVER=native .venv/bin/python -m pytest
 
 grok-check: $(GROK_VENV)
 	$(GROK_PYTHON) -m black --check grok-service/src grok-service/tests && $(GROK_PYTHON) -m ruff check grok-service/src grok-service/tests

--- a/grok-service/src/grok_service/routers/screening.py
+++ b/grok-service/src/grok_service/routers/screening.py
@@ -79,6 +79,22 @@ async def initial_screening(
             "The file may be empty or image-based.",
         )
 
+    # Log extracted PDF text
+    logger.info("=" * 70)
+    logger.info("SCREENING: Received request")
+    logger.info("=" * 70)
+    logger.info("Talent ID: %s", talent.id)
+    logger.info("Talent Name: %s", talent.name)
+    logger.info("PDF Size: %d bytes", len(resume_content))
+    logger.info("Extracted text length: %d characters", len(resume_text))
+    logger.info("=" * 70)
+    logger.info("EXTRACTED PDF TEXT:")
+    logger.info("=" * 70)
+    logger.info(resume_text[:2000] if len(resume_text) > 2000 else resume_text)
+    if len(resume_text) > 2000:
+        logger.info("... (truncated, total %d chars)", len(resume_text))
+    logger.info("=" * 70)
+
     # Analyze resume with Grok
     try:
         grok_service = GrokService()
@@ -115,23 +131,23 @@ async def initial_screening(
         urls=urls,
     )
 
-    # Print result to console
-    print("\n" + "=" * 60)
-    print("SCREENING RESULT")
-    print("=" * 60)
-    print(f"Talent ID: {result.talent_id}")
-    print(f"\nExperiences ({len(result.experiences)}):")
+    # Log result
+    logger.info("=" * 60)
+    logger.info("SCREENING RESULT")
+    logger.info("=" * 60)
+    logger.info("Talent ID: %s", result.talent_id)
+    logger.info("Experiences (%d):", len(result.experiences))
     for i, exp in enumerate(result.experiences, 1):
-        print(f"\n  {i}. {exp.role} at {exp.company}")
+        logger.info("  %d. %s at %s", i, exp.role, exp.company)
         if exp.duration:
-            print(f"     Duration: {exp.duration}")
-        print(f"     Summary: {exp.summary}")
-    print("\nProfile URLs:")
-    print(f"  LinkedIn: {result.urls.linkedin or 'Not found'}")
-    print(f"  X:        {result.urls.x or 'Not found'}")
-    print(f"  GitHub:   {result.urls.github or 'Not found'}")
-    print(f"  GitLab:   {result.urls.gitlab or 'Not found'}")
-    print("=" * 60 + "\n")
+            logger.info("     Duration: %s", exp.duration)
+        logger.info("     Summary: %s", exp.summary)
+    logger.info("Profile URLs:")
+    logger.info("  LinkedIn: %s", result.urls.linkedin or "Not found")
+    logger.info("  X:        %s", result.urls.x or "Not found")
+    logger.info("  GitHub:   %s", result.urls.github or "Not found")
+    logger.info("  GitLab:   %s", result.urls.gitlab or "Not found")
+    logger.info("=" * 60)
 
     return ScreeningResponse(
         success=True,

--- a/grok-service/src/grok_service/services/grok.py
+++ b/grok-service/src/grok_service/services/grok.py
@@ -95,7 +95,18 @@ Resume content:
 Respond with the JSON structure only."""
 
         chat.append(user(prompt))
+
+        logger.info("=" * 70)
+        logger.info("GROK AI: Sending request to Grok...")
+        logger.info("=" * 70)
+
         response = chat.sample()
+
+        logger.info("=" * 70)
+        logger.info("GROK AI: RAW RESPONSE FROM GROK")
+        logger.info("=" * 70)
+        logger.info(response.content)
+        logger.info("=" * 70)
 
         # Parse the JSON response
         try:
@@ -109,7 +120,18 @@ Respond with the JSON structure only."""
                 content = content[:-3]
             content = content.strip()
 
+            logger.info("GROK AI: CLEANED JSON")
+            logger.info("=" * 70)
+            logger.info(content)
+            logger.info("=" * 70)
+
             data = json.loads(content)
+
+            logger.info("GROK AI: PARSED DATA")
+            logger.info("=" * 70)
+            logger.info(json.dumps(data, indent=2))
+            logger.info("=" * 70)
+
             return ResumeAnalysis(
                 experiences=[
                     ExperienceSummary(**exp) for exp in data.get("experiences", [])
@@ -117,8 +139,10 @@ Respond with the JSON structure only."""
                 urls=data.get("urls", {}),
             )
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse Grok response as JSON: {e}")
-            logger.error(f"Raw response: {response.content}")
+            logger.error("=" * 70)
+            logger.error("GROK AI: JSON PARSE ERROR: %s", e)
+            logger.error("Raw response: %s", response.content)
+            logger.error("=" * 70)
             # Return empty result on parse failure
             return ResumeAnalysis(
                 experiences=[],

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -54,8 +54,8 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2",
- "http",
+ "h2 0.3.27",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -91,7 +91,7 @@ checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -311,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +514,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +707,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +737,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -750,6 +782,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -904,7 +951,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -995,6 +1061,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1104,86 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2 0.4.12",
+ "http 1.4.0",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.1",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1149,6 +1328,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1556,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1635,50 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "paperclip"
@@ -1482,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e25ce2c5362c8d48dc89e0f9ca076d507f7c1eabd04f0d593cdf5addff90c"
 dependencies = [
  "heck 0.4.1",
- "http",
+ "http 0.2.12",
  "lazy_static",
  "mime",
  "proc-macro-error",
@@ -1767,6 +2029,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.12",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +2111,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1856,10 +2173,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2311,6 +2660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,6 +2677,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2333,11 +2712,25 @@ dependencies = [
  "env_logger",
  "log",
  "paperclip",
+ "reqwest",
  "serde",
  "serde_json",
  "sqlx",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2465,6 +2858,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +2900,51 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2519,6 +2977,12 @@ checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2632,6 +3096,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,6 +3139,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +3181,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2765,6 +3261,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,3 +21,4 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "uuid", "chrono", "macros", "json", "migrate"] }
 base64 = "0.22"
+reqwest = { version = "0.12", features = ["json", "multipart"] }

--- a/server/migrations/004_add_talent_resume_fields.sql
+++ b/server/migrations/004_add_talent_resume_fields.sql
@@ -1,0 +1,6 @@
+-- Add resume-extracted fields to talents table
+ALTER TABLE talents ADD COLUMN resume_experiences TEXT;
+ALTER TABLE talents ADD COLUMN linkedin_url TEXT;
+ALTER TABLE talents ADD COLUMN x_url TEXT;
+ALTER TABLE talents ADD COLUMN github_url TEXT;
+ALTER TABLE talents ADD COLUMN gitlab_url TEXT;

--- a/server/src/grok_client.rs
+++ b/server/src/grok_client.rs
@@ -1,0 +1,139 @@
+//! Grok service client for resume analysis
+
+use log::{info, error, debug};
+use reqwest::multipart;
+use serde::{Deserialize, Serialize};
+
+/// Experience summary extracted from resume
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExperienceSummary {
+    pub company: String,
+    pub role: String,
+    pub duration: Option<String>,
+    pub summary: String,
+}
+
+/// Profile URLs extracted from resume
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileUrls {
+    pub linkedin: Option<String>,
+    pub x: Option<String>,
+    pub github: Option<String>,
+    pub gitlab: Option<String>,
+}
+
+/// Screening result from Grok service
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScreeningResult {
+    pub talent_id: String,
+    pub experiences: Vec<ExperienceSummary>,
+    pub urls: ProfileUrls,
+}
+
+/// Response from Grok screening endpoint
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScreeningResponse {
+    pub success: bool,
+    pub result: Option<ScreeningResult>,
+    pub error: Option<String>,
+}
+
+/// Talent info for screening request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TalentInfo {
+    pub id: String,
+    pub name: String,
+    pub email: String,
+    pub handle: String,
+    pub skills: String,
+    pub title: String,
+    pub location: Option<String>,
+    pub experience: String,
+    pub bio: Option<String>,
+}
+
+/// Grok service client
+pub struct GrokClient {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl GrokClient {
+    /// Create a new Grok client
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Analyze a resume using the Grok service
+    pub async fn analyze_resume(
+        &self,
+        talent_info: &TalentInfo,
+        pdf_data: &[u8],
+        filename: &str,
+    ) -> Result<ScreeningResponse, String> {
+        info!("[GrokClient] Preparing request...");
+        info!("[GrokClient] Talent: {} ({})", talent_info.name, talent_info.id);
+
+        let talent_json = serde_json::to_string(talent_info)
+            .map_err(|e| format!("Failed to serialize talent info: {}", e))?;
+
+        debug!("[GrokClient] Talent JSON: {}", talent_json);
+
+        let form = multipart::Form::new()
+            .text("talent_info", talent_json.clone())
+            .part(
+                "resume",
+                multipart::Part::bytes(pdf_data.to_vec())
+                    .file_name(filename.to_string())
+                    .mime_str("application/pdf")
+                    .map_err(|e| format!("Failed to set MIME type: {}", e))?,
+            );
+
+        let url = format!("{}/api/v1/screening/initial", self.base_url);
+        info!("[GrokClient] Sending POST to: {}", url);
+        info!("[GrokClient] PDF size: {} bytes, filename: {}", pdf_data.len(), filename);
+
+        let response = self
+            .client
+            .post(&url)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("[GrokClient] Request failed: {}", e);
+                format!("Failed to send request to Grok service: {}", e)
+            })?;
+
+        let status = response.status();
+        info!("[GrokClient] Response status: {}", status);
+
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            error!("[GrokClient] Error response body: {}", body);
+            return Err(format!(
+                "Grok service returned error {}: {}",
+                status, body
+            ));
+        }
+
+        // Get the raw response text first for debugging
+        let response_text = response.text().await
+            .map_err(|e| format!("Failed to read response body: {}", e))?;
+
+        info!("[GrokClient] Raw response: {}", response_text);
+
+        // Parse the JSON
+        let parsed: ScreeningResponse = serde_json::from_str(&response_text)
+            .map_err(|e| {
+                error!("[GrokClient] JSON parse error: {}", e);
+                format!("Failed to parse Grok response: {}", e)
+            })?;
+
+        info!("[GrokClient] Parsed response - success: {}", parsed.success);
+
+        Ok(parsed)
+    }
+}

--- a/server/src/httpd/server.rs
+++ b/server/src/httpd/server.rs
@@ -16,12 +16,16 @@ use super::applications::{
 #[derive(Clone)]
 pub struct AppState {
     pub db_pool: sqlx::SqlitePool,
+    pub grok_service_url: String,
 }
 
 impl AppState {
-    pub async fn new(database_url: &str) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new(database_url: &str, grok_service_url: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let db_pool = crate::database::init_pool(database_url).await?;
-        Ok(Self { db_pool })
+        Ok(Self {
+            db_pool,
+            grok_service_url: grok_service_url.to_string(),
+        })
     }
 }
 
@@ -65,8 +69,8 @@ pub async fn swagger_ui() -> HttpResponseWrapper {
     )
 }
 
-pub async fn run_server(rest_host: &str, rest_port: u16, database_url: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let state = AppState::new(database_url).await?;
+pub async fn run_server(rest_host: &str, rest_port: u16, database_url: &str, grok_service_url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let state = AppState::new(database_url, grok_service_url).await?;
 
     let bind_address = format!("{}:{}", rest_host, rest_port);
     info!("Starting X Talent Pool Server on http://{}", bind_address);

--- a/server/src/httpd/talents.rs
+++ b/server/src/httpd/talents.rs
@@ -35,6 +35,12 @@ async fn create_talent(
         bio: json.bio.clone(),
         verified: json.verified as i32,
         created_at: Utc::now().to_rfc3339(),
+        // Resume-extracted fields (populated later by Grok service)
+        resume_experiences: None,
+        linkedin_url: None,
+        x_url: None,
+        github_url: None,
+        gitlab_url: None,
     };
     let inserted = crate::database::create_talent(&pool, &new_talent).await
         .map_err(actix_web::error::ErrorInternalServerError)?;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod database;
+pub mod grok_client;
 pub mod httpd;
 pub mod models;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -16,6 +16,10 @@ struct Args {
     /// Database URL
     #[arg(long, env = "DATABASE_URL", default_value = "sqlite://talents.db?mode=rwc")]
     pub database_url: String,
+
+    /// Grok service URL for resume analysis
+    #[arg(long, env = "GROK_SERVICE_URL", default_value = "http://localhost:8001")]
+    pub grok_service_url: String,
 }
 
 #[tokio::main]
@@ -28,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("OpenAPI docs: http://{}:{}/", args.host, args.port);
     info!("Swagger UI: http://{}:{}/", args.host, args.port);
 
-    run_server(&args.host, args.port, &args.database_url).await?;
+    run_server(&args.host, args.port, &args.database_url, &args.grok_service_url).await?;
 
     Ok(())
 }

--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -16,6 +16,12 @@ pub struct Talent {
     pub bio: Option<String>,
     pub verified: i32,
     pub created_at: String,
+    // Resume-extracted fields
+    pub resume_experiences: Option<String>,  // JSON array of experiences
+    pub linkedin_url: Option<String>,
+    pub x_url: Option<String>,
+    pub github_url: Option<String>,
+    pub gitlab_url: Option<String>,
 }
 
 

--- a/server/src/queries/get_talent_by_email.sql
+++ b/server/src/queries/get_talent_by_email.sql
@@ -1,3 +1,1 @@
-SELECT id, name, email, handle, skills, avatar, title, location, experience, bio, verified, created_at
-FROM talents
-WHERE email = ?
+SELECT * FROM talents WHERE email = ?

--- a/server/src/queries/update_talent_resume_fields.sql
+++ b/server/src/queries/update_talent_resume_fields.sql
@@ -1,0 +1,8 @@
+UPDATE talents
+SET resume_experiences = ?,
+    linkedin_url = ?,
+    x_url = ?,
+    github_url = ?,
+    gitlab_url = ?
+WHERE id = ?
+RETURNING *;

--- a/ui/src/lib/components/talent-detail-dialog.svelte
+++ b/ui/src/lib/components/talent-detail-dialog.svelte
@@ -14,10 +14,13 @@
 		FileText,
 		Eye,
 		Loader2,
-		Building2
+		Building2,
+		Github,
+		Linkedin,
+		Twitter
 	} from 'lucide-svelte';
 	import PdfPreviewDialog from './pdf-preview-dialog.svelte';
-	import type { Talent, Application, Job } from '$lib/types';
+	import type { Talent, Application, Job, ExperienceSummary } from '$lib/types';
 
 	let {
 		talent,
@@ -89,6 +92,21 @@
 		if (!talent.skills) return [];
 		if (Array.isArray(talent.skills)) return talent.skills;
 		return (talent.skills as unknown as string).split(',').map((s) => s.trim()).filter((s) => s);
+	});
+
+	// Parse resume experiences from JSON string
+	const resumeExperiences = $derived(() => {
+		if (!talent.resume_experiences) return [];
+		try {
+			return JSON.parse(talent.resume_experiences) as ExperienceSummary[];
+		} catch {
+			return [];
+		}
+	});
+
+	// Check if there are any social links
+	const hasSocialLinks = $derived(() => {
+		return talent.linkedin_url || talent.x_url || talent.github_url || talent.gitlab_url;
 	});
 
 	// Format date
@@ -188,6 +206,67 @@
 					<div class="flex flex-wrap gap-2">
 						{#each skills() as skill}
 							<Badge variant="outline">{skill}</Badge>
+						{/each}
+					</div>
+				</div>
+			{/if}
+
+			<!-- Social Links (from Grok analysis) -->
+			{#if hasSocialLinks()}
+				<Separator />
+				<div class="space-y-2">
+					<h3 class="text-sm font-semibold">Social Profiles</h3>
+					<div class="flex flex-wrap gap-2">
+						{#if talent.linkedin_url}
+							<Button variant="outline" size="sm" href={talent.linkedin_url} target="_blank" rel="noopener noreferrer">
+								<Linkedin class="mr-1 h-4 w-4" />
+								LinkedIn
+							</Button>
+						{/if}
+						{#if talent.x_url}
+							<Button variant="outline" size="sm" href={talent.x_url} target="_blank" rel="noopener noreferrer">
+								<Twitter class="mr-1 h-4 w-4" />
+								X
+							</Button>
+						{/if}
+						{#if talent.github_url}
+							<Button variant="outline" size="sm" href={talent.github_url} target="_blank" rel="noopener noreferrer">
+								<Github class="mr-1 h-4 w-4" />
+								GitHub
+							</Button>
+						{/if}
+						{#if talent.gitlab_url}
+							<Button variant="outline" size="sm" href={talent.gitlab_url} target="_blank" rel="noopener noreferrer">
+								<ExternalLink class="mr-1 h-4 w-4" />
+								GitLab
+							</Button>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
+			<!-- Work Experience (from Grok analysis) -->
+			{#if resumeExperiences().length > 0}
+				<Separator />
+				<div class="space-y-3">
+					<h3 class="text-sm font-semibold">Work Experience (from Resume)</h3>
+					<div class="space-y-3">
+						{#each resumeExperiences() as exp, i}
+							<div class="rounded-lg border p-3">
+								<div class="flex items-start gap-2">
+									<Building2 class="mt-0.5 h-4 w-4 text-muted-foreground" />
+									<div class="flex-1">
+										<div class="font-medium text-sm">{exp.role}</div>
+										<div class="text-sm text-muted-foreground">{exp.company}</div>
+										{#if exp.duration}
+											<div class="text-xs text-muted-foreground mt-0.5">{exp.duration}</div>
+										{/if}
+										{#if exp.summary}
+											<p class="text-sm mt-2">{exp.summary}</p>
+										{/if}
+									</div>
+								</div>
+							</div>
 						{/each}
 					</div>
 				</div>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1,3 +1,10 @@
+export interface ExperienceSummary {
+	company: string;
+	role: string;
+	duration?: string;
+	summary: string;
+}
+
 export interface Talent {
 	id: string;
 	name: string;
@@ -12,6 +19,12 @@ export interface Talent {
 	verified: boolean;
 	created_at: string;
 	saved?: boolean; // local UI state
+	// Grok-extracted resume fields
+	resume_experiences?: string; // JSON array of ExperienceSummary
+	linkedin_url?: string;
+	x_url?: string;
+	github_url?: string;
+	gitlab_url?: string;
 }
 
 export interface Job {


### PR DESCRIPTION
- Add GrokClient in Rust to call grok-service for resume analysis
- Update Talent model with resume-extracted fields (experiences, URLs)
- Add database migration for new talent fields
- Display extracted work experiences and social links in talent dialog
- Fix gRPC DNS resolver issue on macOS (GRPC_DNS_RESOLVER=native)
- Add logging standards to CLAUDE.md (use log libraries, not print)
- Replace print statements with proper logging in Python and Rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)